### PR TITLE
Normalize weights

### DIFF
--- a/src/maxgcp/estimators.py
+++ b/src/maxgcp/estimators.py
@@ -1,6 +1,6 @@
 from typing import TypeAlias
 
-import jax
+import jax  # type: ignore
 import jax.numpy as jnp  # type: ignore
 import numpy as np  # type: ignore
 import scipy.linalg  # type: ignore
@@ -57,7 +57,11 @@ def fit_heritability(cov_G: ArrayLike, cov_P: ArrayLike) -> NDArray:
     lhs = cov_G_sqrt @ np.linalg.pinv(cov_P) @ cov_G_sqrt
     _, evecs = np.linalg.eig(lhs)
     weights = np.linalg.pinv(cov_G_sqrt) @ evecs
-    return np.asarray(weights)
+    weights = np.asarray(weights)
+
+    # Normalize weights so that projections have unit variance
+    weights = weights / np.sqrt(np.diag(weights.T @ cov_P @ weights))
+    return weights
 
 
 def fit_coheritability(cov_G: ArrayLike, cov_P: ArrayLike) -> NDArray:
@@ -83,7 +87,11 @@ def fit_coheritability(cov_G: ArrayLike, cov_P: ArrayLike) -> NDArray:
     check_inputs(cov_G, cov_P)
 
     weights, _, _, _ = jnp.linalg.lstsq(cov_P, cov_G, rcond=None)
-    return np.asarray(weights)
+    weights = np.asarray(weights)
+
+    # Normalize weights so that projections have unit variance
+    weights = weights / np.sqrt(np.diag(weights.T @ cov_P @ weights))
+    return weights
 
 
 def fit_genetic_correlation(phenotype_idx: int, cov_G: ArrayLike) -> NDArray:

--- a/src/maxgcp/summary.py
+++ b/src/maxgcp/summary.py
@@ -1,6 +1,6 @@
-import numpy as np
-import pandas as pd
-from numpy.typing import NDArray
+import numpy as np  # type: ignore
+import pandas as pd  # type: ignore
+from numpy.typing import NDArray  # type: ignore
 
 
 def conditional_heritability(weights: NDArray, G: NDArray, P: NDArray) -> NDArray:


### PR DESCRIPTION
The weights that solve these equations are identical up to an arbitrary factor, which has no effect on any of the genetic properties we use. To simplify future use, this PR normalizes the coefficients so that all projected phenotypes have unit variance.